### PR TITLE
Improve visual hierarchy and interaction accessibility

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -193,17 +193,17 @@ export default function HomeClient({
           {!isParentAuthenticated ? (
             <>
               <div className="grid gap-3">
-                <button onClick={handleGoogleSignIn} className="min-h-11 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-3 font-bold hover:bg-zinc-200">
+                <button onClick={handleGoogleSignIn} className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-3 font-bold hover:bg-zinc-200">
                   Google でログイン
                 </button>
-                <button onClick={handlePasskeySignIn} className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-3 font-bold hover:bg-zinc-200">
+                <button onClick={handlePasskeySignIn} className="focus-ring inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-3 font-bold hover:bg-zinc-200">
                   <KeyRound className="h-4 w-4" />
                   Passkey でログイン
                 </button>
                 {DEV_SHORTCUT_ENABLED && AUTH_MODE === 'development' && (
                   <button
                     onClick={handleDevShortcut}
-                    className="min-h-11 rounded-xl border-2 border-amber-300 bg-amber-100 px-4 py-3 font-bold text-amber-800 hover:bg-amber-200"
+                    className="focus-ring min-h-11 rounded-xl border-2 border-amber-300 bg-amber-100 px-4 py-3 font-bold text-amber-800 hover:bg-amber-200"
                   >
                     開発ショートカットでログイン
                   </button>
@@ -221,13 +221,13 @@ export default function HomeClient({
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   disabled={isSendingMagicLink}
-                  className="min-h-11 rounded-xl border-2 border-zinc-300 bg-white px-3"
+                  className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 bg-white px-3"
                   placeholder="parent@example.com"
                 />
                 <button
                   type="submit"
                   disabled={isSendingMagicLink}
-                  className="min-h-11 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {isSendingMagicLink ? '送信中...' : 'Magic Link を送信'}
                 </button>
@@ -267,10 +267,10 @@ export default function HomeClient({
                 required
                 value={newChildName}
                 onChange={(e) => setNewChildName(e.target.value)}
-                className="min-h-11 rounded-xl border-2 border-zinc-300 px-3"
+                className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 px-3"
                 placeholder="たろう"
               />
-              <button type="submit" className="min-h-11 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200">
+              <button type="submit" className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200">
                 子プロフィールを作成
               </button>
             </form>
@@ -280,14 +280,14 @@ export default function HomeClient({
             <>
               <form className="grid gap-3" onSubmit={handleChildSubmit}>
                 <label className="text-sm font-bold text-zinc-700">学習する子ども</label>
-                <select value={selectedChildId} onChange={(e) => setSelectedChildId(e.target.value)} className="min-h-11 rounded-xl border-2 border-zinc-300 px-3">
+                <select value={selectedChildId} onChange={(e) => setSelectedChildId(e.target.value)} className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 px-3">
                   {children.map((child) => (
                     <option key={child.id} value={child.id}>
                       {child.display_name}
                     </option>
                   ))}
                 </select>
-                <button type="submit" className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200">
+                <button type="submit" className="focus-ring inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border-2 border-zinc-300 bg-slate-100 px-4 py-2 font-bold text-zinc-800 hover:bg-slate-200">
                   学習をはじめる
                   <ArrowRight className="h-4 w-4" />
                 </button>
@@ -302,10 +302,10 @@ export default function HomeClient({
                   required
                   value={newChildName}
                   onChange={(e) => setNewChildName(e.target.value)}
-                  className="min-h-11 rounded-xl border-2 border-zinc-300 px-3"
+                  className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 px-3"
                   placeholder="はなこ"
                 />
-                <button type="submit" className="min-h-11 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-2 font-bold text-zinc-700 hover:bg-zinc-200">
+                <button type="submit" className="focus-ring min-h-11 rounded-xl border-2 border-zinc-300 bg-zinc-100 px-4 py-2 font-bold text-zinc-700 hover:bg-zinc-200">
                   追加する
                 </button>
               </form>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", "Meiryo", "Noto Sans JP", sans-serif;
-  --font-display: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic UI", "Yu Gothic", "Meiryo", "Noto Sans JP", sans-serif;
+  --font-display: "Hiragino Maru Gothic ProN", "Hiragino Sans", "BIZ UDPGothic", "Yu Gothic UI", "Yu Gothic", "Meiryo", "Noto Sans JP", sans-serif;
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-secondary: var(--secondary);
@@ -200,6 +200,10 @@
 
   .font-display {
     font-family: var(--font-display);
+  }
+
+  .focus-ring {
+    @apply focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-slate-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-white;
   }
 
   .shadow-brutal {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,10 +64,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body
-        className="bg-slate-50 font-sans antialiased selection:bg-slate-200 selection:text-slate-900"
-        style={{ backgroundImage: "none" }}
-      >
+      <body className="bg-background font-sans antialiased text-foreground selection:bg-slate-200 selection:text-slate-900">
         <ServiceWorkerRegister />
         {children}
       </body>

--- a/src/app/quiz/QuizClient.tsx
+++ b/src/app/quiz/QuizClient.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, CheckCircle, PartyPopper, X, XCircle } from 'lucide-react';
+import { ArrowLeft, ArrowRight, CheckCircle, PartyPopper, X, XCircle } from 'lucide-react';
 import { calculateSessionPoints } from '@/lib/points';
 import { fireCorrectEffect } from '@/lib/effects/confetti';
 import { ICON_SIZE, ICON_STROKE } from '@/lib/ui/iconTokens';
@@ -162,6 +162,12 @@ export default function QuizClient({
     }
   };
 
+  const handleBackToDashboard = () => {
+    const canLeave = window.confirm('学習を中断してダッシュボードに戻りますか？');
+    if (!canLeave) return;
+    router.push('/dashboard');
+  };
+
   const tone = resolveSubjectTone(genre.parent_id ?? genre.id, genre.color_hint);
 
   if (questions.length === 0) {
@@ -190,6 +196,18 @@ export default function QuizClient({
 
   return (
     <div className="flex h-full flex-1 flex-col gap-4">
+      <div className="flex items-center justify-between gap-3 rounded-2xl border-4 border-zinc-400 bg-white p-3 shadow-brutal-sm sm:p-4">
+        <button
+          type="button"
+          onClick={handleBackToDashboard}
+          className="focus-ring inline-flex min-h-11 items-center gap-2 rounded-full border-2 border-zinc-300 bg-zinc-100 px-3 py-2 text-sm font-black text-zinc-700 hover:bg-zinc-200"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          戻る
+        </button>
+        <p className="text-sm font-black text-zinc-700 sm:text-base">{genre.name}</p>
+      </div>
+
       <div className="rounded-2xl border-4 border-zinc-400 bg-white p-4 shadow-brutal-sm">
         <div className="mb-2 flex items-center justify-between text-sm font-black text-zinc-700">
           <span>
@@ -263,7 +281,7 @@ export default function QuizClient({
       <button
         disabled={!isAnswered || isSubmitting}
         onClick={handleNext}
-        className="mt-auto inline-flex min-h-11 items-center justify-center gap-2 rounded-full border-4 border-zinc-400 bg-zinc-100 px-6 py-3 text-lg font-black text-zinc-900 shadow-brutal transition-all hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
+        className="focus-ring mt-auto inline-flex min-h-11 items-center justify-center gap-2 rounded-full border-4 border-zinc-400 bg-zinc-100 px-6 py-3 text-lg font-black text-zinc-900 shadow-brutal transition-all hover:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {currentIndex < questions.length - 1 ? 'つぎへ' : isSubmitting ? '保存中...' : '結果を見る'}
         <ArrowRight className="h-5 w-5" />

--- a/src/app/result/ResultClient.tsx
+++ b/src/app/result/ResultClient.tsx
@@ -188,7 +188,7 @@ export default function ResultClient({
             height={52}
             loader={passthroughImageLoader}
             unoptimized
-            className="h-11 w-11 shrink-0 rounded-xl border-2 border-zinc-300 bg-white object-contain p-1 sm:h-13 sm:w-13"
+            className="h-11 w-11 shrink-0 rounded-xl border-2 border-zinc-300 bg-white object-contain p-1 sm:h-12 sm:w-12"
             onError={(event) => {
               event.currentTarget.src = '/icons/icon-192.png';
             }}

--- a/src/components/layout/PageShell.tsx
+++ b/src/components/layout/PageShell.tsx
@@ -12,7 +12,7 @@ export default function PageShell({
   mainClassName = 'flex flex-col gap-8',
 }: PageShellProps) {
   return (
-    <div className="flex min-h-screen-safe flex-col items-center bg-zinc-50 px-4 py-5 sm:px-6 sm:py-8 lg:px-8 dark:bg-zinc-950">
+    <div className="flex min-h-screen-safe flex-col items-center bg-background px-4 py-5 text-foreground sm:px-6 sm:py-8 lg:px-8">
       <main className={`w-full ${maxWidthClass} ${mainClassName}`}>{children}</main>
     </div>
   );


### PR DESCRIPTION
## Summary
- separate display typography from body typography to improve heading hierarchy
- align layout shells with design tokens (`bg-background` / `text-foreground`) instead of hard-coded colors
- add visible keyboard focus styles to home-page form controls and action buttons
- fix invalid Tailwind size class in result badge toast
- add an explicit back/abort affordance at the top of quiz screen with confirmation

## Validation
- `npm run build` was attempted in this worktree before env setup and failed with `next: command not found`
- after dependencies/env were restored, app booted successfully via `npm run dev` (user-verified)